### PR TITLE
Add details about deliverables to 2024-12-18-agenda.md

### DIFF
--- a/meetings/2024/2024-12-18-agenda.md
+++ b/meetings/2024/2024-12-18-agenda.md
@@ -30,7 +30,10 @@ The SING call will be held at 16:00 UTC ([The World Clock](https://www.timeandda
 
 * Participants Introduction (2 minutes roundtable)
 * Group presentation
-* Our Deliverables and decision to auto-publish them
+* Our [Deliverables](https://www.w3.org/2024/11/security-ig-charter.html#deliverables), editors for them, and deciding whether to auto-publish them
+  * [Self-Review Questionnaire for Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/)
+  * A Threat Model for the Web
+  * Threat Modeling Guide
 * [Reviews that need volunteer(s)](https://github.com/w3c/security-request/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee+)
 * Next meeting
 


### PR DESCRIPTION
I think this is all the deliverables that need to be addressed.

2¢: The initial "editors" for the threat models probably just need to be people willing to write a first draft. It's possible for those drafts to exist for a while on Github as Editor's Drafts before we make the Group Decision to publish them to TR space as [Draft Notes](https://www.w3.org/policies/process/#draft-note) (which will eventually be followed by re-publication as Notes once their content has group consensus). If I understand correctly, a decision to auto-publish them won't take effect until we also decide to publish them at all, and it's fine to make those decisions in either order.