### PR TITLE
Ask for Sec/Priv questionnaire editors in 2025-02-04_agenda.md

### DIFF
--- a/meetings/2025/2025-02-04_agenda.md
+++ b/meetings/2025/2025-02-04_agenda.md
@@ -35,6 +35,8 @@ The SING call will be held at 15:00 UTC ([The World Clock](https://www.timeandda
      * [charters](https://github.com/w3c/strategy/issues?q=is%3Aissue+is%3Aopen+label%3A%22Horizontal+review+requested%22++-label%3A%22Security+review+completed%22+-label%3ACouncil)
   * VCDM Review
   * File format Threat Model (Generic)
+* Documents that need volunteer editors:
+  * [Security/Privacy Questionnaire](https://w3c.github.io/security-questionnaire/)
 
 
 * Next meeting


### PR DESCRIPTION
[The TAG wants to stop editing the Security/Privacy Questionnaire](https://github.com/w3c/security-questionnaire/pull/185) now that we have formal groups for both security and privacy, but to actually hand it off, we need a volunteer editor from the Security IG.

I can't usually attend the time that's been selected for IG meetings, so I shouldn't volunteer for security (and I'm not actually a security person), but I'm happy to help the volunteer get up to speed and help with technical issues on an ongoing basis.